### PR TITLE
Add .gitattributes for PNG images

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.png binary


### PR DESCRIPTION
## Summary
- ensure Git handles PNG images as binary files

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6878d7b2ba00832dbc5e2dacf04f3397