### PR TITLE
Improve card overview design

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,23 +3,67 @@
 <head>
     <meta charset="UTF-8">
     <title>Übersichtsseite</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <style>
-        body { font-family: Arial, sans-serif; margin: 0; padding: 1rem; }
-        .page-container { display: flex; flex-wrap: wrap; gap: 1rem; }
-        .page { border: 1px solid #ccc; padding: 1rem; width: 300px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
+        body {
+            font-family: Arial, sans-serif;
+            margin: 0;
+            padding: 1rem;
+            background-color: #f5f5f5;
+        }
+
+        .page-container {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+            gap: 1rem;
+            margin-top: 1rem;
+        }
+
+        .card {
+            background: #ffffff;
+            padding: 1rem;
+            border-radius: 8px;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+            text-decoration: none;
+            color: inherit;
+            transition: transform 0.2s ease, box-shadow 0.2s ease;
+        }
+
+        .card:hover {
+            transform: translateY(-5px);
+            box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+        }
+
+        .card h2 {
+            margin: 0 0 0.5rem 0;
+            font-size: 1.25rem;
+        }
+
+        .card p {
+            margin: 0;
+            color: #555;
+        }
     </style>
 </head>
 <body>
     <h1>Übersichtsseite</h1>
     <div class="page-container">
-        <div class="page">
+        <a class="card" href="rotierendes-oktagon-mit-ball.html">
             <h2>Rotierendes Oktagon mit Ball</h2>
-            <a href="rotierendes-oktagon.html">Seite öffnen</a>
-        </div>
-        <div class="page">
-            <h2>Rotierendes Oktagon mit Ball</h2>
-            <a href="rotierendes-oktagon-mit-ball.html">Seite öffnen</a>
-        </div>
+            <p>Zur Demo</p>
+        </a>
+        <a class="card" href="MangaJapanCL.html">
+            <h2>MangaJapanCL</h2>
+            <p>Fotogalerie</p>
+        </a>
+        <a class="card" href="https://gimini-app-black.vercel.app/">
+            <h2>Geschichtenerzähler</h2>
+            <p>Externe Seite</p>
+        </a>
+        <a class="card" href="japan-plan-2025.html">
+            <h2>Japan Plan 2025</h2>
+            <p>Interaktiver Reiseplan</p>
+        </a>
     </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- modernize overview page styling with cards in a responsive grid
- add links for MangaJapanCL, Geschichtenerzähler and Japan Plan 2025

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878e1157868832d9861b916442f3d71