### PR TITLE
Improve card layout and gallery styling

### DIFF
--- a/MangaJapanCL.html
+++ b/MangaJapanCL.html
@@ -1,1 +1,51 @@
-<html><head><meta content="text/html; charset=UTF-8" http-equiv="content-type"><style type="text/css">ol{margin:0;padding:0}table td,table th{padding:0}.c2{color:#000000;font-weight:400;text-decoration:none;vertical-align:baseline;font-size:11pt;font-family:"Arial";font-style:normal}.c1{padding-top:0pt;padding-bottom:0pt;line-height:1.15;orphans:2;widows:2;text-align:left}.c0{background-color:#ffffff;max-width:451.4pt;padding:14.2pt 72pt 72pt 72pt}.title{padding-top:0pt;color:#000000;font-size:26pt;padding-bottom:3pt;font-family:"Arial";line-height:1.15;page-break-after:avoid;orphans:2;widows:2;text-align:left}.subtitle{padding-top:0pt;color:#666666;font-size:15pt;padding-bottom:16pt;font-family:"Arial";line-height:1.15;page-break-after:avoid;orphans:2;widows:2;text-align:left}li{color:#000000;font-size:11pt;font-family:"Arial"}p{margin:0;color:#000000;font-size:11pt;font-family:"Arial"}h1{padding-top:20pt;color:#000000;font-size:20pt;padding-bottom:6pt;font-family:"Arial";line-height:1.15;page-break-after:avoid;orphans:2;widows:2;text-align:left}h2{padding-top:18pt;color:#000000;font-size:16pt;padding-bottom:6pt;font-family:"Arial";line-height:1.15;page-break-after:avoid;orphans:2;widows:2;text-align:left}h3{padding-top:16pt;color:#434343;font-size:14pt;padding-bottom:4pt;font-family:"Arial";line-height:1.15;page-break-after:avoid;orphans:2;widows:2;text-align:left}h4{padding-top:14pt;color:#666666;font-size:12pt;padding-bottom:4pt;font-family:"Arial";line-height:1.15;page-break-after:avoid;orphans:2;widows:2;text-align:left}h5{padding-top:12pt;color:#666666;font-size:11pt;padding-bottom:4pt;font-family:"Arial";line-height:1.15;page-break-after:avoid;orphans:2;widows:2;text-align:left}h6{padding-top:12pt;color:#666666;font-size:11pt;padding-bottom:4pt;font-family:"Arial";line-height:1.15;page-break-after:avoid;font-style:italic;orphans:2;widows:2;text-align:left}</style></head><body class="c0 doc-content"><p class="c1"><span style="overflow: hidden; display: inline-block; margin: 0.00px 0.00px; border: 0.00px solid #000000; transform: rotate(0.00rad) translateZ(0px); -webkit-transform: rotate(0.00rad) translateZ(0px); width: 337.67px; height: 506.50px;"><img alt="" src="images/image1.jpg" style="width: 337.67px; height: 506.50px; margin-left: 0.00px; margin-top: 0.00px; transform: rotate(0.00rad) translateZ(0px); -webkit-transform: rotate(0.00rad) translateZ(0px);" title=""></span><span style="overflow: hidden; display: inline-block; margin: 0.00px 0.00px; border: 0.00px solid #000000; transform: rotate(0.00rad) translateZ(0px); -webkit-transform: rotate(0.00rad) translateZ(0px); width: 329.00px; height: 496.68px;"><img alt="" src="images/image4.jpg" style="width: 329.00px; height: 496.68px; margin-left: 0.00px; margin-top: 0.00px; transform: rotate(0.00rad) translateZ(0px); -webkit-transform: rotate(0.00rad) translateZ(0px);" title=""></span><span style="overflow: hidden; display: inline-block; margin: 0.00px 0.00px; border: 0.00px solid #000000; transform: rotate(0.00rad) translateZ(0px); -webkit-transform: rotate(0.00rad) translateZ(0px); width: 329.00px; height: 467.00px;"><img alt="" src="images/image3.jpg" style="width: 329.00px; height: 467.00px; margin-left: 0.00px; margin-top: 0.00px; transform: rotate(0.00rad) translateZ(0px); -webkit-transform: rotate(0.00rad) translateZ(0px);" title=""></span><span style="overflow: hidden; display: inline-block; margin: 0.00px 0.00px; border: 0.00px solid #000000; transform: rotate(0.00rad) translateZ(0px); -webkit-transform: rotate(0.00rad) translateZ(0px); width: 411.50px; height: 300.00px;"><img alt="" src="images/image5.jpg" style="width: 411.50px; height: 300.00px; margin-left: 0.00px; margin-top: 0.00px; transform: rotate(0.00rad) translateZ(0px); -webkit-transform: rotate(0.00rad) translateZ(0px);" title=""></span><span style="overflow: hidden; display: inline-block; margin: 0.00px 0.00px; border: 0.00px solid #000000; transform: rotate(0.00rad) translateZ(0px); -webkit-transform: rotate(0.00rad) translateZ(0px); width: 328.69px; height: 327.60px;"><img alt="" src="images/image2.jpg" style="width: 328.69px; height: 327.60px; margin-left: 0.00px; margin-top: 0.00px; transform: rotate(0.00rad) translateZ(0px); -webkit-transform: rotate(0.00rad) translateZ(0px);" title=""></span></p></body></html>
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>MangaJapanCL Galerie</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 0;
+            padding: 1rem;
+            background-color: #f5f5f5;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+        }
+        h1 {
+            margin-bottom: 1rem;
+        }
+        .gallery {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 1rem;
+            justify-content: center;
+            max-width: 1000px;
+        }
+        .gallery img {
+            width: 200px;
+            height: auto;
+            border-radius: 8px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }
+        @media (max-width: 500px) {
+            .gallery img {
+                width: 100%;
+                max-width: 300px;
+            }
+        }
+    </style>
+</head>
+<body>
+    <h1>MangaJapanCL</h1>
+    <div class="gallery">
+        <img src="images/image1.jpg" alt="Bild 1">
+        <img src="images/image2.jpg" alt="Bild 2">
+        <img src="images/image3.jpg" alt="Bild 3">
+        <img src="images/image4.jpg" alt="Bild 4">
+        <img src="images/image5.jpg" alt="Bild 5">
+    </div>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -3,23 +3,76 @@
 <head>
     <meta charset="UTF-8">
     <title>Übersichtsseite</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <style>
-        body { font-family: Arial, sans-serif; margin: 0; padding: 1rem; }
-        .page-container { display: flex; flex-wrap: wrap; gap: 1rem; }
-        .page { border: 1px solid #ccc; padding: 1rem; width: 300px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
+        body {
+            font-family: Arial, sans-serif;
+            margin: 0;
+            padding: 2rem 1rem;
+            background-color: #f5f5f5;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            min-height: 100vh;
+            text-align: center;
+        }
+
+        .page-container {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            gap: 1.5rem;
+            width: 100%;
+            margin-top: 2rem;
+        }
+
+        .card {
+            background: #ffffff;
+            padding: 1rem;
+            border-radius: 8px;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+            text-decoration: none;
+            color: inherit;
+            transition: transform 0.2s ease, box-shadow 0.2s ease;
+            width: 100%;
+            max-width: 400px;
+        }
+
+        .card:hover {
+            transform: translateY(-5px);
+            box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+        }
+
+        .card h2 {
+            margin: 0 0 0.5rem 0;
+            font-size: 1.25rem;
+        }
+
+        .card p {
+            margin: 0;
+            color: #555;
+        }
     </style>
 </head>
 <body>
     <h1>Übersichtsseite</h1>
     <div class="page-container">
-        <div class="page">
+        <a class="card" href="rotierendes-oktagon-mit-ball.html">
             <h2>Rotierendes Oktagon mit Ball</h2>
-            <a href="rotierendes-oktagon.html">Seite öffnen</a>
-        </div>
-        <div class="page">
-            <h2>Rotierendes Oktagon mit Ball</h2>
-            <a href="rotierendes-oktagon-mit-ball.html">Seite öffnen</a>
-        </div>
+            <p>Zur Demo</p>
+        </a>
+        <a class="card" href="MangaJapanCL.html">
+            <h2>MangaJapanCL</h2>
+            <p>Fotogalerie</p>
+        </a>
+        <a class="card" href="https://gimini-app-black.vercel.app/">
+            <h2>Geschichtenerzähler</h2>
+            <p>Externe Seite</p>
+        </a>
+        <a class="card" href="https://japan2025-mauve.vercel.app/" target="_blank" rel="noopener">
+            <h2>Japan Plan 2025</h2>
+            <p>Interaktiver Reiseplan</p>
+        </a>
     </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- make overview cards centered and link Japan Plan 2025 externally
- simplify MangaJapanCL and show gallery in a responsive flex layout

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6878e1157868832d9861b916442f3d71