### PR TITLE
Update index links for games

### DIFF
--- a/index.html
+++ b/index.html
@@ -181,11 +181,11 @@
             <h2>Dungeon Spiel</h2>
             <p>Rogue-like Abenteuer</p>
         </a>
-        <a class="card" href="MemoryCardGame" target="_blank" rel="noopener">
+        <a class="card" href="MemoryCardGame.html" target="_blank" rel="noopener">
             <h2>Memory Card Game</h2>
             <p>Kartenpaare finden</p>
         </a>
-        <a class="card" href="Lavalampe" target="_blank" rel="noopener">
+        <a class="card" href="Lavalampe.html" target="_blank" rel="noopener">
             <h2>Virtuelle Lavalampe</h2>
             <p>Hypnotische Animationen</p>
         </a>


### PR DESCRIPTION
## Summary
- fix the links for **MemoryCardGame.html** and **Lavalampe.html** on the overview page

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687b7db638ac832d8d9417b86ffe02d3