### PR TITLE
Add CarPolice link to index

### DIFF
--- a/index.html
+++ b/index.html
@@ -172,6 +172,10 @@
             <h2>Agadir Reiseplan 2</h2>
             <p>Erweiterte Reiseübersicht</p>
         </a>
+        <a class="card" href="CarPolice.html" target="_blank" rel="noopener">
+            <h2>Car Policy Generator</h2>
+            <p>Dienstwagen-Richtlinie erstellen</p>
+        </a>
         <a class="card" href="rotierendes-oktagon-mit-ball.html" target="_blank" rel="noopener">
             <h2>Rotierendes Oktagon mit Ball</h2>
             <p>Zur Demo</p>


### PR DESCRIPTION
## Summary
- link CarPolice.html from the overview page below the travel plan cards

## Testing
- `htmlhint index.html` *(fails: `htmlhint: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_687d2ae426f0832dbe8ac5ed035d26cf