### PR TITLE
Remove retrosnow2 card from overview

### DIFF
--- a/index.html
+++ b/index.html
@@ -233,10 +233,6 @@
             <h2>Jon Snow Retro Battle</h2>
             <p>Retro-Schlacht</p>
         </a>
-        <a class="card" href="retrosnow2.html" target="_blank" rel="noopener">
-            <h2>Jon Snow Retro Battle 2</h2>
-            <p>TIC-80 Variante</p>
-        </a>
     </div>
 
     <script>


### PR DESCRIPTION
## Summary
- delete the link to `retrosnow2.html` from the overview page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687e1bee9f08832dbbd41d3c57629faf