### PR TITLE
Add Hot or Not Hollywood link to overview page

### DIFF
--- a/index.html
+++ b/index.html
@@ -418,6 +418,9 @@
         <a class="card" href="PocketDungeon.html" target="_blank" rel="noopener">
           <h2>Pocket Dungeon</h2><p>Mini-Abenteuer</p>
         </a>
+        <a class="card" href="hotornothollywood.html" target="_blank" rel="noopener">
+          <h2>Hot or Not Hollywood</h2><p>Star-Rating Spiel</p>
+        </a>
         <a class="card" href="explore_quiz.html" target="_blank" rel="noopener">
           <h2>Explore Quiz</h2><p>Flaggen-Spiel</p>
         </a>


### PR DESCRIPTION
## Summary
- Add Hot or Not Hollywood card to games section of overview page

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e224f1108832d875fc2e97c2a8cae