### PR TITLE
Add Verbrenner-Aus 2030 link to Info section

### DIFF
--- a/index.html
+++ b/index.html
@@ -357,6 +357,9 @@
         <h2 class="category-title">Info</h2>
       </div>
       <div class="grid">
+        <a class="card" href="Verbrenneraus2030.html" target="_blank" rel="noopener">
+          <h2>Verbrenner-Aus 2030</h2><p>Analyse für Dienstwagen</p>
+        </a>
         <a class="card" href="CarPolice.html" target="_blank" rel="noopener">
           <h2>Car Policy 100 Fahrzeuge</h2><p>Dienstwagen-Richtlinie</p>
         </a>


### PR DESCRIPTION
## Summary
- Add Verbrenner-Aus 2030 analysis link at the top of the Info section on the overview page.

## Testing
- `npx -y htmlhint index.html`


------
https://chatgpt.com/codex/tasks/task_e_689080f70044832dacaa849621780bfa