### PR TITLE
Remove Hot or Not Hollywood link from overview

### DIFF
--- a/index.html
+++ b/index.html
@@ -456,9 +456,6 @@
         <a class="card" href="PocketDungeon.html" target="_blank" rel="noopener">
           <h2>Pocket Dungeon</h2><p>Mini-Abenteuer</p>
         </a>
-        <a class="card" href="hot-or-not-hollywood.html" target="_blank" rel="noopener">
-          <h2>Hot or Not Hollywood</h2><p>Star-Rating Spiel</p>
-        </a>
         <a class="card" href="explore_quiz.html" target="_blank" rel="noopener">
           <h2>Explore Quiz</h2><p>Flaggen-Spiel</p>
         </a>


### PR DESCRIPTION
## Summary
- remove Hot or Not Hollywood card from index overview page

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_6891fd5015c4832da85a04efff0ead5a