### PR TITLE
Add productivity tools and energy price info

### DIFF
--- a/StromGasPreis.html
+++ b/StromGasPreis.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Strom- & Gaspreis Übersicht</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 2rem; background: #f4f4f4; color: #333; }
+        h1 { color: #24496c; }
+        ul { line-height: 1.6; }
+        a { color: #24496c; }
+    </style>
+</head>
+<body>
+    <h1>Strom- & Gaspreis Übersicht</h1>
+    <p>Links zu aktuellen Preisentwicklungen in Deutschland:</p>
+    <ul>
+        <li><a href="https://www.verivox.de/strom/strompreisentwicklung/" target="_blank" rel="noopener noreferrer">Strompreisentwicklung</a></li>
+        <li><a href="https://www.verivox.de/gas/gaspreisentwicklung/" target="_blank" rel="noopener noreferrer">Gaspreisentwicklung</a></li>
+    </ul>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -446,6 +446,7 @@
         <div class="category-header"><span class="category-icon">📊</span><h2 class="category-title">Information & Analysen</h2></div>
         <div class="grid">
           <a class="card" href="Battlefield6.html" target="_blank" rel="noopener noreferrer"><h2>Battlefield 6 Open Beta</h2><p>Reaktionen & Loadouts</p></a>
+          <a class="card" href="StromGasPreis.html" target="_blank" rel="noopener noreferrer"><h2>Strom & Gaspreis</h2><p>Übersicht</p></a>
           <a class="card" href="grafikkarten.html" target="_blank" rel="noopener noreferrer"><h2>RTX-Grafikkarten Vergleich</h2><p>NVIDIA Übersicht</p></a>
           <a class="card" href="Verbrenneraus2030.html" target="_blank" rel="noopener noreferrer"><h2>Verbrenner-Aus 2030</h2><p>Analyse für Dienstwagen</p></a>
           <a class="card" href="CarPolice.html" target="_blank" rel="noopener noreferrer"><h2>Car Policy 100 Fahrzeuge</h2><p>Dienstwagen-Richtlinie</p></a>
@@ -458,6 +459,10 @@
       <section id="tools-section" class="category-section category-tools" data-category="tools" role="tabpanel" aria-labelledby="tools-tab">
         <div class="category-header"><span class="category-icon">🔧</span><h2 class="category-title">Produktivitäts-Tools</h2></div>
         <div class="grid">
+          <a class="card" href="regenradar.html" target="_blank" rel="noopener noreferrer"><h2>Regenradar</h2><p>Timelapse</p></a>
+          <a class="card" href="MietpreiseHH.html" target="_blank" rel="noopener noreferrer"><h2>Mietspiegel HH</h2><p>Hamburg &amp; Umgebung</p></a>
+          <a class="card" href="PDFfragmich.html" target="_blank" rel="noopener noreferrer"><h2>Frag das PDF</h2><p>Lokale Suche</p></a>
+          <a class="card" href="Ideenscout.html" target="_blank" rel="noopener noreferrer"><h2>Ideenscout</h2><p>20 Variationen</p></a>
           <a class="card" href="API.Prompt.Verbesserer.html" target="_blank" rel="noopener noreferrer"><h2>AI Prompt Verbesserer</h2><p>Prompts optimieren</p></a>
           <a class="card" href="groq-code-assistant.html" target="_blank" rel="noopener noreferrer"><h2>Groq Code Assistant</h2><p>KI-Hilfswerkzeug</p></a>
           <a class="card" href="moodify-app.html" target="_blank" rel="noopener noreferrer"><h2>Moodify</h2><p>Stimmungs-App</p></a>


### PR DESCRIPTION
## Summary
- add Regenradar, Mietspiegel HH, Frag das PDF, und Ideenscout zu den Produktivitäts-Tools
- verlinke Strom & Gaspreis Seite im Info-Bereich und erstelle entsprechende HTML-Seite

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689894e8d150832da69268b46f371266