### PR TITLE
Remove Reise-Deal-Finder from overview

### DIFF
--- a/index.html
+++ b/index.html
@@ -473,7 +473,6 @@
           <a class="card" href="ExpenseTrackerAI-Insights.html" target="_blank" rel="noopener noreferrer"><h2>Expense Tracker</h2><p>AI-Insights</p></a>
           <a class="card" href="AI-Content-Generator.html" target="_blank" rel="noopener noreferrer"><h2>AI Content Generator</h2><p>Texte erzeugen</p></a>
           <a class="card" href="NPCdialog.html" target="_blank" rel="noopener noreferrer"><h2>NPC-Dialog</h2><p>Seed-Lore Chat</p></a>
-          <a class="card" href="Reise-Deal-Finder.html" target="_blank" rel="noopener noreferrer"><h2>Reise-Deal-Finder</h2><p>Reiseschnäppchen finden</p></a>
         </div>
       </section>
 


### PR DESCRIPTION
## Summary
- remove Reise-Deal-Finder entry from the overview page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899c90b618c832da21f13e15c5427f5